### PR TITLE
fix: 🐛 Warning に基づき v14 で削除予定の @next/font を削除した

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "election-bulletin-2023",
   "version": "0.1.0",
   "devDependencies": {
-    "@next/font": "^13.4.7",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,11 +119,6 @@
   dependencies:
     glob "7.1.7"
 
-"@next/font@^13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.4.7.tgz#32f9e2c4a856e23370d2be4b46eddaccce11b88d"
-  integrity sha512-l28ifb3pjKznQeXmiCD5VXkmqdpMrcUQMr4ZChAgTKrjckl/aGyRLOIlL/ABhTHmzMujdt/TTWUsdABArNK5gA==
-
 "@next/swc-darwin-arm64@13.4.7":
   version "13.4.7"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.7.tgz#5e36c26dda5b0bc0ea15d8555d0abd71a1ef4b5d"


### PR DESCRIPTION
ウォーニング